### PR TITLE
test: Implement the use of Sass Modules in a simple way

### DIFF
--- a/src/components/button/_c.button.scss
+++ b/src/components/button/_c.button.scss
@@ -1,3 +1,5 @@
+@use "../../mixins/" as *;
+
 .my-button {
   @include set-button-layout();
 }

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -1,1 +1,1 @@
-@import "./c.button";
+@forward "./c.button";

--- a/src/mixins/_index.scss
+++ b/src/mixins/_index.scss
@@ -1,1 +1,1 @@
-@import "s.button";
+@forward "s.button";

--- a/src/mixins/_s.button.scss
+++ b/src/mixins/_s.button.scss
@@ -1,3 +1,5 @@
+@use "../themes/green" as *;
+
 @mixin set-button-layout() {
   background-color: $primary;
   color: white;

--- a/src/styles.css.map
+++ b/src/styles.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["components/button/_c.button.scss","mixins/_s.button.scss","themes/_green.scss"],"names":[],"mappings":"AAAA;ECCE,kBCDQ;EDER;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA","file":"styles.css"}
+{"version":3,"sourceRoot":"","sources":["components/button/_c.button.scss","mixins/_s.button.scss","themes/_green.scss"],"names":[],"mappings":"AAEA;ECCE,kBCHQ;EDIR;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA;EACA","file":"styles.css"}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,8 +1,2 @@
-// user theme
-@import "themes/green";
-
-// settings
-@import "mixins";
-
 // components
-@import "./components/button/";
+@import "components/button/";


### PR DESCRIPTION
Dans cet exemple d'implémentation, j'implémente de façon simple l'usage de Sass Modules à savoir : 

- J'utilise la règle `@forward` à la place de `@import` dans mes fichiers partials "globaux" _(index.scss)_ afin de continuer à "acheminer" le contenu des fichiers importés
- Etant donné qu'on ne peut plus transmettre, les mixins et les variables de façon global, plusieurs choses sont donc à changer dans la façon d'importer mes mixins et variables afin de les utiliser:
  * Dans mon fichier `styles.scss`, je supprime donc les appels à mes fichiers `themes/green` & `mixins`
  * Dans le fichier de mon composant `c.button`; j'importe à l'aide de la règle `@use` mon fichier de `mixins`; car j'ai besoin d'utiliser la mixin dans mon composant
  * Dans mon fichier de mixin `s.button`; j'importe à l'aide de la règle `@use` mon fichier de thème `themes/green` car je vais avoir besoin des variables de mon thème dans la mixin concernée.

Cette implémentation simple des Sass Modules marche bien, mais pose quand le problème du fait que mon fichier de thème, est appelé de façon explicite à l'intérieur du fichier de mon composant, auquel le user final n'aura pas accès s'il veut personnaliser le thème.

Il faut donc trouver une solution de continuer à passer les variables du thèmes au composant, sans avoir à appeler un fichier dont le nom fait explicitement référence à tel ou tel thème.