### PR TITLE
test: replace the call to a specific theme file by a generic file

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -1,0 +1,1 @@
+@forward "./themes/green";

--- a/src/mixins/_s.button.scss
+++ b/src/mixins/_s.button.scss
@@ -1,4 +1,4 @@
-@use "../themes/green" as *;
+@use "../theme" as *;
 
 @mixin set-button-layout() {
   background-color: $primary;


### PR DESCRIPTION
L'implémentation #1 marche bien mais cependant pose un problème en raison du fait que pour avoir accès aux variables du thème, il faut importer à l'aide de la règle `@use` de façon spécifique le fichier theme concerné.

Cela pose un problème car dans le cadre de notre librairie, le user n'a pas accès aux fichiers des composants, et donc ne peut pas changer le thème appelé dans le fichier du composant.

Du coup, pour contourner ce problème, il faut que soit importé dans les composants, non pas un fichier spécifique, mais un fichier générique.

Pour cela : 
- Je créé un fichier générique (dont le nom ne fait pas référence explicitement à un thème en particulier)
- Dans ce fichier, j'utilise la règle `@forward` pour "acheminer" les variables de mon thème par défaut
- Dans le fichier de mon composant, j'utilise la règle `@use` pour importer le fichier générique

Cela marche parfaitement.
Maintenant il faut voir de quel façon on peut personnaliser le thème depuis le fichier générique.